### PR TITLE
fix contribution not show in safari

### DIFF
--- a/static/js/contributions.js
+++ b/static/js/contributions.js
@@ -11,7 +11,7 @@ let contributions;
   contributions = JSON.parse(dom.getAttribute('data'));
   let year = 0;
   for (const item of contributions) {
-    item.publishDate = decodeURI(item.publishDate);
+    item.publishDate = decodeURI(item.publishDate).replace(' ','T');
     item.date = new Date(item.publishDate);
     if (item.date.getFullYear() > year) {
       year = item.date.getFullYear();


### PR DESCRIPTION
The bug is shown in the picture. The contribution is not rendered properly in safari. 
This is due to the new Date(string) statement, which requires the input string to use capital 'T' as a separator instead of using white space. 
<img width="968" alt="Screen Shot 2020-11-19 at 4 42 38 AM" src="https://user-images.githubusercontent.com/25622540/99649432-33b9c780-2a22-11eb-9f87-15415fe41402.png">
