### PR TITLE
use env variable to control google analysis load; update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,20 @@
 # github-style
 
+## Init hugo site
+
+```bash
+hugo new site mysite
+cd mysite
+```
+
 ## Install the theme
 
 ```bash
-mkdir themes
 git submodule add git@github.com:MeiK2333/github-style.git themes/github-style
 ```
 
 ## Update the theme
-
+If you just installed the theme, it is already in the lattest version. If not, you can update using the below commands
 ```bash
 cd themes/github-style
 git pull
@@ -20,7 +26,7 @@ git pull
 hugo new about.md
 ```
 
-add `layout = "about"` to `content/about.md`
+This creates content/about.md file. Then add `layout = "about"` to `content/about.md`, and remove the line `draft:true`
 
 ```
 ---
@@ -30,6 +36,25 @@ layout: "about"
 ---
 
 about me
+```
+
+## Add new posts
+Hugo will create a post with `draft: true`, change it to false in order for it to show in the website. 
+```
+hugo new posts/title_of_the_post.md
+```
+
+## Limit display content
+Use `<!--more-->` to seperate content that will display in the posts page as abstraction and the rest of the content.
+```
+---
+title: "title"
+date: 2019-10-22T18:46:47+08:00
+draft: false
+---
+abstraction show in the post page
+<!--more-->
+other content
 ```
 
 ## config.toml example
@@ -55,3 +80,40 @@ copyright = "© 2019. Theme by <a href=\"https://github.com/MeiK2333/github-styl
   url = "https://example.com"
   keywords = "blog, google analytics"
 ```
+
+## deploy.sh example
+There are various way to deploy to github, here is a link to official [document](https://gohugo.io/hosting-and-deployment/hosting-on-github/). 
+
+Here is an sample. Note line 22 have `env HUGO_ENV="production"`, makes sure googleAnalysis is loaded during production, but is not loaded when we are testing it in localhost.
+
+```bash
+#!/bin/sh
+
+if [ "`git status -s`" ]
+then
+    echo "The working directory is dirty. Please commit any pending changes."
+    exit 1;
+fi
+
+echo "Deleting old publication"
+rm -rf public
+mkdir public
+git worktree prune
+rm -rf .git/worktrees/public/
+
+echo "Checking out gh-pages branch into public"
+git worktree add -B gh-pages public origin/gh-pages
+
+echo "Removing existing files"
+rm -rf public/*
+
+echo "Generating site"
+env HUGO_ENV="production" hugo -t github-style
+
+echo "Updating gh-pages branch"
+cd public && git add --all && git commit -m "Publishing to gh-pages (publish.sh)"
+
+#echo "Pushing to github"
+#git push --all
+```
+Then you can verify the site is working and use `git push --all` to push the change to github. If you don't want to check again every time, you can uncomment the `#git push --all` in the script.

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -57,6 +57,8 @@
 
     <!-- Extended head section-->
     {{ partial "extended_head.html" . }}
-
-    {{ template "_internal/google_analytics_async.html" . }}
+    
+    {{ if eq (getenv "HUGO_ENV") "production"}}
+        {{ template "_internal/google_analytics_async.html" . }}
+    {{ end }}
 </head>


### PR DESCRIPTION
- add environment variable, only load google analysis when HUGO_ENV is set to "production";  [相关博客](https://liz2020.github.io/blogs/posts/setup-googleanalytics/)
- update the readme to include new posts, a separate line, deploy.sh etc.