### PR TITLE
fix: 修复baseurl为xx/xx时跳转错误的bug

### DIFF
--- a/layouts/partials/menus.html
+++ b/layouts/partials/menus.html
@@ -19,8 +19,8 @@
               </svg>
               Overview
             </a>
-            <a class="UnderlineNav-item {{ if .IsSection }} selected {{ end }}{{ if eq .Type "tags" }} selected {{ end }}"
-              href="/post/">
+            <a class="UnderlineNav-item {{ if .IsSection }} selected {{ end }}{{ if eq .Type " tags" }} selected {{ end
+              }}" href="{{ .Site.BaseURL }}/post/">
               <svg class="octicon octicon-repo UnderlineNav-octicon hide-sm" height="16" viewBox="0 0 16 16"
                 version="1.1" width="16">
                 <path fill-rule="evenodd"

--- a/layouts/partials/mobile-menus.html
+++ b/layouts/partials/mobile-menus.html
@@ -13,7 +13,7 @@
       Overview
     </a>
     <a class='UnderlineNav-item  {{ if .IsSection }} selected {{ end }}{{ if eq .Type "tags" }} selected {{ end }}'
-      href="/post/">
+      href="{{ .Site.BaseURL }}/post/">
       <svg class="octicon octicon-repo UnderlineNav-octicon hide-sm" height="16" viewBox="0 0 16 16" version="1.1"
         width="16">
         <path fill-rule="evenodd"

--- a/layouts/partials/posts.html
+++ b/layouts/partials/posts.html
@@ -10,7 +10,7 @@
           for <strong>{{ .Params.title }}</strong>
         </div>
         <div class="TableObject-item text-right v-align-top">
-          <a class="issues-reset-query text-normal d-inline-block ml-3" href="/post/">
+          <a class="issues-reset-query text-normal d-inline-block ml-3" href="{{ .Site.BaseURL }}/post/">
             <svg class="octicon octicon-x issues-reset-query-icon mt-1" viewBox="0 0 16 16" version="1.1" width="16"
               height="16">
               <path fill-rule="evenodd"
@@ -41,7 +41,7 @@
             <div class="f6 text-gray mt-2">
               {{ with .Params.tags }}
               {{ range $tag := (first 5 .) }}
-              <a class="muted-link mr-3" href="{{ relURL (print "/tags/" . | urlize) }}">
+              <a class="muted-link mr-3" href="{{ relURL (print " /tags/" . | urlize) }}">
                 <svg class="octicon octicon-tag" viewBox="0 0 16 16" version="1.1" width="16" height="16">
                   <path fill-rule="evenodd"
                     d="M2.5 7.775V2.75a.25.25 0 01.25-.25h5.025a.25.25 0 01.177.073l6.25 6.25a.25.25 0 010 .354l-5.025 5.025a.25.25 0 01-.354 0l-6.25-6.25a.25.25 0 01-.073-.177zm-1.5 0V2.75C1 1.784 1.784 1 2.75 1h5.025c.464 0 .91.184 1.238.513l6.25 6.25a1.75 1.75 0 010 2.474l-5.026 5.026a1.75 1.75 0 01-2.474 0l-6.25-6.25A1.75 1.75 0 011 7.775zM6 5a1 1 0 100 2 1 1 0 000-2z">
@@ -53,8 +53,8 @@
               {{ end }}
 
               Created
-              <relative-time datetime="{{ .PublishDate.Format "Mon, 02 Jan 2006 15:04:05 -0700" }}" class="no-wrap"
-                title="{{ .PublishDate.Format "Mon, 02 Jan 2006 15:04:05 -0700" }}">
+              <relative-time datetime="{{ .PublishDate.Format " Mon, 02 Jan 2006 15:04:05 -0700" }}" class="no-wrap"
+                title="{{ .PublishDate.Format " Mon, 02 Jan 2006 15:04:05 -0700" }}">
                 {{ .PublishDate.Format "Mon, 02 Jan 2006 15:04:05 -0700" }}
               </relative-time>
             </div>


### PR DESCRIPTION
如果baseUrl为xx/xx，如2xiao.github.io/blog，点击posts会跳转到2xiao.github.io/posts, 路由错误。
这个pr修复了这种情况。
修复方法为：相对路由改为绝对路由：
`href="{{ .Site.BaseURL }}/post/"`