### PR TITLE
Generate rss url based on relative URL

### DIFF
--- a/layouts/partials/user-profile.html
+++ b/layouts/partials/user-profile.html
@@ -148,7 +148,7 @@
           {{ end }}
 
           {{ if .Site.Params.rss }}
-          <a class="avatar-group-item" href="{{ "/index.xml" | absURL }}">
+          <a class="avatar-group-item" href="{{ "index.xml" | absURL }}">
             <img alt="@rss" width="32" height="32" src="{{ "images/rss.png" | absURL }}" class="avatar">
           </a>
           {{ end }}


### PR DESCRIPTION
Generate correct URL even if Site.BaseURL is not domain apex.