### PR TITLE
添加Github图标动态跟随显示模式

### DIFF
--- a/layouts/partials/user-profile.html
+++ b/layouts/partials/user-profile.html
@@ -108,7 +108,10 @@
           <h2 class="mb-2 h4">Organizations</h2>
           {{ if .Site.Params.github}}
           <a class="avatar-group-item" href="https://github.com/{{ .Site.Params.github }}">
-            <img alt="@github" width="32" height="32" src="{{ "images/github.png" | absURL }}" class="avatar">
+            <svg id="github-icon" viewBox="0 0 16 16" version="1.1" width="32" height="32">
+              <path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z">
+              </path>
+            </svg>
           </a>
           {{ end }}
 
@@ -190,4 +193,14 @@ window.onscroll = function (e) {
     document.querySelector('#headerStuck').classList.remove('is-stuck');
   }
 };
+var style = localStorage.getItem('data-color-mode');
+iconElement = document.getElementById('github-icon');
+if (style == 'light') {
+  iconElement.setAttribute('fill', '#24292e');
+  iconElement.setAttribute('class', 'Header-link');
+}
+else {
+  iconElement.removeAttribute('fill');
+  iconElement.setAttribute('class', 'octicon Header-link');
+}
 </script>

--- a/layouts/partials/user-profile.html
+++ b/layouts/partials/user-profile.html
@@ -106,9 +106,10 @@
 
         <div class="border-top color-border-secondary pt-3 mt-3 clearfix hide-sm hide-md">
           <h2 class="mb-2 h4">Organizations</h2>
+          <div style="display:flex;justify-content:flex-start;flex-wrap:wrap;margin-bottom:3px;">
           {{ if .Site.Params.github}}
-          <a class="avatar-group-item" href="https://github.com/{{ .Site.Params.github }}">
-            <svg id="github-icon" viewBox="0 0 16 16" version="1.1" width="32" height="32">
+          <a style="margin: 0 10px 10px 0;" href="https://github.com/{{ .Site.Params.github }}">
+            <svg id="github-icon" viewBox="0 0 16 16" version="1.1" width="32" height="32" fill="#24292e">
               <path fill-rule="evenodd" d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z">
               </path>
             </svg>
@@ -116,37 +117,37 @@
           {{ end }}
 
           {{ if .Site.Params.twitter}}
-          <a class="avatar-group-item" href="https://twitter.com/{{ .Site.Params.twitter }}">
+          <a style="margin: 0 10px 10px 0;" href="https://twitter.com/{{ .Site.Params.twitter }}">
             <img alt="@twitter" width="32" height="32" src="{{ "images/twitter.png" | absURL }}" class="avatar">
           </a>
           {{ end }}
 
           {{ if .Site.Params.facebook}}
-          <a class="avatar-group-item" href="https://facebook.com/{{ .Site.Params.facebook }}">
+          <a style="margin: 0 10px 10px 0;" href="https://facebook.com/{{ .Site.Params.facebook }}">
             <img alt="@facebook" width="32" height="32" src="{{ "images/facebook.png" | absURL }}" class="avatar">
           </a>
           {{ end }}
 
           {{ if .Site.Params.linkedin }}
-          <a class="avatar-group-item" href="https://linkedin.com/in/{{ .Site.Params.linkedin }}">
+          <a style="margin: 0 10px 10px 0;" href="https://linkedin.com/in/{{ .Site.Params.linkedin }}">
             <img alt="@linkedin" width="32" height="32" src="{{ "images/linkedin.png" | absURL }}" class="avatar">
           </a>
           {{ end }}
 
           {{ if .Site.Params.instagram }}
-          <a class="avatar-group-item" href="https://instagram.com/{{ .Site.Params.instagram }}">
+          <a style="margin: 0 10px 10px 0;" href="https://instagram.com/{{ .Site.Params.instagram }}">
             <img alt="@instagram" width="32" height="32" src="{{ "images/instagram.png" | absURL }}" class="avatar">
           </a>
           {{ end }}
 
           {{ if .Site.Params.tumblr }}
-          <a class="avatar-group-item" href="https://{{ .Site.Params.tumblr }}.tumblr.com/">
+          <a style="margin: 0 10px 10px 0;" href="https://{{ .Site.Params.tumblr }}.tumblr.com/">
             <img alt="@tumblr" width="32" height="32" src="{{ "images/tumblr.png" | absURL }}" class="avatar">
           </a>
           {{ end }}
 
           {{ if .Site.Params.stackoverflow }}
-          <a class="avatar-group-item" href="https://stackoverflow.com/u/{{ .Site.Params.stackoverflow }}">
+          <a style="margin: 0 10px 10px 0;" href="https://stackoverflow.com/u/{{ .Site.Params.stackoverflow }}">
             <img alt="@stackoverflow" width="32" height="32" src="{{ "images/stackoverflow.png" | absURL }}" class="avatar">
           </a>
           {{ end }}
@@ -154,11 +155,11 @@
           {{ if .Site.Params.links }}
           {{ range .Site.Params.links }}
           {{ if .icon }}
-          <a class="avatar-group-item" href="{{ .href }}">
+          <a style="margin: 0 10px 10px 0;" href="{{ .href }}">
             <img alt="@{{ .title }}" width="32" height="32" src="{{ .icon }}" class="avatar">
           </a>
           {{ else }}
-          <a class="avatar-group-item" href="{{ .href }}">
+          <a style="margin: 0 10px 10px 0;" href="{{ .href }}">
             <img alt="@{{ .title }}" width="32" height="32" src='{{ "images/link.png" | absURL }}' class="avatar">
           </a>
           {{ end }}
@@ -166,10 +167,11 @@
           {{ end }}
 
           {{ if .Site.Params.rss }}
-          <a class="avatar-group-item" href="{{ "index.xml" | absURL }}">
+          <a style="margin: 0 10px 10px 0;" href="{{ "index.xml" | absURL }}">
             <img alt="@rss" width="32" height="32" src="{{ "images/rss.png" | absURL }}" class="avatar">
           </a>
           {{ end }}
+         </div>
         </div>
       </div>
     </div>
@@ -197,10 +199,10 @@ var style = localStorage.getItem('data-color-mode');
 iconElement = document.getElementById('github-icon');
 if (style == 'light') {
   iconElement.setAttribute('fill', '#24292e');
-  iconElement.setAttribute('class', 'Header-link');
 }
 else {
   iconElement.removeAttribute('fill');
-  iconElement.setAttribute('class', 'octicon Header-link');
+  iconElement.setAttribute('class', 'octicon');
+  iconElement.setAttribute('color', '#f0f6fc');
 }
 </script>

--- a/static/js/theme-mode.js
+++ b/static/js/theme-mode.js
@@ -4,13 +4,13 @@ function switchTheme() {
 
   if (currentStyle == 'light') {
     setTheme('dark');
-    iconElement.removeAttribute('fill');
-    iconElement.setAttribute('class', 'octicon Header-link');
+    iconElement.setAttribute('class', 'octicon');
+    iconElement.setAttribute('color', '#f0f6fc');
   }
   else {
     setTheme('light');
-    iconElement.setAttribute('fill', '#24292e');
-    iconElement.setAttribute('class', 'Header-link');
+    iconElement.removeAttribute('color');
+    iconElement.removeAttribute('class');
   }
 }
 

--- a/static/js/theme-mode.js
+++ b/static/js/theme-mode.js
@@ -1,11 +1,16 @@
 function switchTheme() {
   const currentStyle = currentTheme();
+  var iconElement = document.getElementById('github-icon');
 
   if (currentStyle == 'light') {
     setTheme('dark');
+    iconElement.removeAttribute('fill');
+    iconElement.setAttribute('class', 'octicon Header-link');
   }
   else {
     setTheme('light');
+    iconElement.setAttribute('fill', '#24292e');
+    iconElement.setAttribute('class', 'Header-link');
   }
 }
 


### PR DESCRIPTION
我是这个主题的使用者，#83 更新背景颜色后导致我自定义过的 Github 图标异常，所以使用 svg 作为新的图标，并支持模式切换时图标跟随变化。

更新后效果如下：

* 夜间模式：

![批注 2021-11-26 003401](https://user-images.githubusercontent.com/43537771/143477211-ff70e7c1-3af6-4e0a-aaf5-a2740bf78fce.png)

* 白天模式：

![批注 2021-11-26 00340112](https://user-images.githubusercontent.com/43537771/143477235-da35afa4-bca6-4316-b40c-a3f60f55fa2f.png)



