### PR TITLE
修改样式适配移动端头像上下间距对齐

### DIFF
--- a/layouts/partials/user-profile.html
+++ b/layouts/partials/user-profile.html
@@ -2,7 +2,7 @@
 <div class="container-xl px-3 px-md-4 px-lg-5">
   <div class="gutter-condensed gutter-lg flex-column flex-md-row d-flex">
     <div class="flex-shrink-0 col-12 col-md-3 mb-4 mb-md-0">
-      <div class="h-card mt-md-n5">
+      <div class="h-card mt-md-n5" style="margin-top:24px">
         <div class="user-profile-sticky-bar js-user-profile-sticky-bar d-none d-md-block" id="headerStuck">
           <div class="user-profile-mini-vcard d-table">
             <span class="user-profile-mini-avatar d-table-cell v-align-middle lh-condensed-ultra pr-2">


### PR DESCRIPTION
由于屏幕宽度未达到移动端水准时已经有 !important 声明，直接显式增大 div 元素顶部边缘，适配移动端。

修改前：
![批注 2021-11-29 212550](https://user-images.githubusercontent.com/43537771/143876393-788e6d41-1360-40d9-a048-e3554ad6b562.png)

修改后：
![批注 2021-11-29 2125500](https://user-images.githubusercontent.com/43537771/143876438-1ed48fbf-154f-45bc-9e72-7c0b59f99ffc.png)


