### PR TITLE
fix(static): fix blank post activity

### DIFF
--- a/static/js/github-style.js
+++ b/static/js/github-style.js
@@ -43,16 +43,18 @@ function switchYear(year) {
   for (const item of contributions) {
     if (item.date >= startDate && item.date <= endDate) {
       posts.push(item);
-      if (!ms.includes(item.date.getMonth())) {
-        ms.push(item.date.getMonth());
+      const time = item.date.getFullYear().toString() + "-" + item.date.getMonth().toString();
+      if (!ms.includes(time)) {
+        ms.push(time);
       }
     }
   }
   posts.sort((a, b) => { return b - a });
   document.querySelector('#posts-activity').innerHTML = '';
-  for (const month of ms) {
+  for (const time of ms) {
     const node = document.createElement('div');
-    node.innerHTML = monthly(year, month, posts);
+    const array = time.split("-");
+    node.innerHTML = monthly(array[0], Number(array[1]), posts);
     document.querySelector('#posts-activity').appendChild(node);
   }
 


### PR DESCRIPTION
修复了当时间跨越年份时， Post activity 会有空白显示的 bug 。

复现步骤：
将 `static/js/github-style.js` 中的 `const now = new Date();` 设置为一个旧的时间就可以复现。


