### PR TITLE
Add demosite to theme.toml

### DIFF
--- a/theme.toml
+++ b/theme.toml
@@ -6,6 +6,7 @@ license = "MIT"
 licenselink = "https://github.com/MeiK2333/github-style/blob/master/LICENSE"
 description = "github-style hugo theme"
 homepage = "https://github.com/MeiK2333"
+demosite = "https://meik2333.com/"
 tags = ["blog", "google analytics"]
 features = ["google analytics"]
 min_version = "0.41"


### PR DESCRIPTION
So that a direct link to the demo site is generated at https://themes.gohugo.io/themes/github-style/, just like [here](https://themes.gohugo.io/themes/hugo-book/).

If this is the demo site, of course.

