### PR TITLE
Tags with spaces don't render correctly.

### DIFF
--- a/layouts/partials/tags.html
+++ b/layouts/partials/tags.html
@@ -6,7 +6,7 @@
 <div class="f6 text-gray mt-2 tags border-bottom">
 	{{range $taxonomyname, $taxonomy := .Site.Taxonomies}}
 		{{range $key, $value := $taxonomy }}
-			<a class="muted-link mr-3" href="{{ relURL (print "tags/" $key) }}/">
+			<a class="muted-link mr-3" href="{{ relURL (print "tags/" $key) | urlize }}/">
 				<svg class="octicon octicon-tag" viewBox="0 0 16 16" version="1.1" width="16" height="16">
 					<path fill-rule="evenodd"
 						d="M2.5 7.775V2.75a.25.25 0 01.25-.25h5.025a.25.25 0 01.177.073l6.25 6.25a.25.25 0 010 .354l-5.025 5.025a.25.25 0 01-.354 0l-6.25-6.25a.25.25 0 01-.073-.177zm-1.5 0V2.75C1 1.784 1.784 1 2.75 1h5.025c.464 0 .91.184 1.238.513l6.25 6.25a1.75 1.75 0 010 2.474l-5.026 5.026a1.75 1.75 0 01-2.474 0l-6.25-6.25A1.75 1.75 0 011 7.775zM6 5a1 1 0 100 2 1 1 0 000-2z">


### PR DESCRIPTION
I noticed that my tags at the top of the homepage 404'd when clicked (well, the ones with spaces in them anyway).

Just needs consistency with the other templates.