### PR TITLE
Missing tag name on posts landing page

### DIFF
--- a/layouts/partials/posts.html
+++ b/layouts/partials/posts.html
@@ -7,7 +7,7 @@
         <div class="user-repo-search-results-summary TableObject-item TableObject-item--primary v-align-top">
           <strong>{{ len .Pages }}</strong>
           results
-          for <strong>{{ .Params.title }}</strong>
+          for <strong>{{ .Title }}</strong>
         </div>
         <div class="TableObject-item text-right v-align-top">
           <a class="issues-reset-query text-normal d-inline-block ml-3" href="{{ .Site.BaseURL }}/post/">


### PR DESCRIPTION
Using hugo v0.123.4-21a41003c4633b142ac565c52da22924dc30637a+extended

This is blank unless I make the change here.