### PR TITLE
Allows use of categories and tags

### DIFF
--- a/layouts/partials/tags.html
+++ b/layouts/partials/tags.html
@@ -1,19 +1,25 @@
 <style>
-	.tags{
-		padding: 15px 0;
-	}
+	.tags{ padding: 15px 0; }
 </style>
 <div class="f6 text-gray mt-2 tags border-bottom">
-	{{range $taxonomyname, $taxonomy := .Site.Taxonomies}}
-		{{range $key, $value := $taxonomy }}
-			<a class="muted-link mr-3" href="{{ relURL (print "tags/" $key) }}/">
-				<svg class="octicon octicon-tag" viewBox="0 0 16 16" version="1.1" width="16" height="16">
-					<path fill-rule="evenodd"
-						d="M2.5 7.775V2.75a.25.25 0 01.25-.25h5.025a.25.25 0 01.177.073l6.25 6.25a.25.25 0 010 .354l-5.025 5.025a.25.25 0 01-.354 0l-6.25-6.25a.25.25 0 01-.073-.177zm-1.5 0V2.75C1 1.784 1.784 1 2.75 1h5.025c.464 0 .91.184 1.238.513l6.25 6.25a1.75 1.75 0 010 2.474l-5.026 5.026a1.75 1.75 0 01-2.474 0l-6.25-6.25A1.75 1.75 0 011 7.775zM6 5a1 1 0 100 2 1 1 0 000-2z">
-					</path>
-				</svg>
-				{{$key}}
-			</a>
-		{{end}}
-	{{end}}
+	{{ range $taxonomy, $terms := site.Taxonomies }}
+	{{ range $term := $terms }}
+	<a class="muted-link mr-3" href="{{ .Page.RelPermalink }}">
+		{{ if eq $taxonomy "tags" }}
+		<svg class="octicon octicon-tag" viewBox="0 0 16 16" version="1.1" width="16" height="16">
+			<path fill-rule="evenodd"
+				d="M2.5 7.775V2.75a.25.25 0 01.25-.25h5.025a.25.25 0 01.177.073l6.25 6.25a.25.25 0 010 .354l-5.025 5.025a.25.25 0 01-.354 0l-6.25-6.25a.25.25 0 01-.073-.177zm-1.5 0V2.75C1 1.784 1.784 1 2.75 1h5.025c.464 0 .91.184 1.238.513l6.25 6.25a1.75 1.75 0 010 2.474l-5.026 5.026a1.75 1.75 0 01-2.474 0l-6.25-6.25A1.75 1.75 0 011 7.775zM6 5a1 1 0 100 2 1 1 0 000-2z">
+			</path>
+		</svg>
+		{{ else }}
+		<svg class="octicon octicon-package" viewBox="0 0 16 16" version="1.1" width="16" height="16">
+			<path fill-rule="evenodd"
+				d="M8.878.392a1.75 1.75 0 00-1.756 0l-5.25 3.045A1.75 1.75 0 001 4.951v6.098c0 .624.332 1.2.872 1.514l5.25 3.045a1.75 1.75 0 001.756 0l5.25-3.045c.54-.313.872-.89.872-1.514V4.951c0-.624-.332-1.2-.872-1.514L8.878.392zM7.875 1.69a.25.25 0 01.25 0l4.63 2.685L8 7.133 3.245 4.375l4.63-2.685zM2.5 5.677v5.372c0 .09.047.171.125.216l4.625 2.683V8.432L2.5 5.677zm6.25 8.271l4.625-2.683a.25.25 0 00.125-.216V5.677L8.75 8.432v5.516z">
+			</path>
+		</svg>
+		{{ end }}
+		{{ .Page.Title | lower }}
+	</a>
+	{{ end }}
+	{{ end }}
 </div>


### PR DESCRIPTION
I probably wouldn't handle it like this if I were writing it from scratch, but this is a suggested solution for having both tags _and_ categories present on the site.

```
---
title: "Wheelie"
date: 2024-03-01T22:06:25Z
draft: false
tags: ["skoolkit", "wheelie", "zx spectrum", "z80"]
categories:
  - "Disassembly"
---
```

The problem is, categories are defined by default so you end up with an empty page; e.g. https://meik2333.com/categories/

The alternative is to remove it, which can be done in the hugo config file (so you could perhaps instead stick this in the example file given).

```
[Taxonomies]
  tag = "tags"
```

(If you don't define `category = "categories"` then it's removed).