### PR TITLE
Update 404.html

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -34,7 +34,10 @@
 
     </div>
     {{ partial "footer.html" . }}
-    {{ template "_internal/google_analytics_async.html" . }}
+    <!-- Google Analytics -->
+    {{ if eq (getenv "HUGO_ENV") "production"}}
+      {{ template "_internal/google_analytics.html" . }}
+    {{ end }}
 </body>
 
 </html>


### PR DESCRIPTION
Google Analytics async template is deprecated:

https://github.com/gohugoio/hugo/blob/master/tpl/tplimpl/embedded/templates/google_analytics_async.html#L1

I've also wrapped it in an `if` statement so it doesn't track non-production environments.