### PR TITLE
Fix twitter javascript

### DIFF
--- a/layouts/partials/user-profile.html
+++ b/layouts/partials/user-profile.html
@@ -208,13 +208,15 @@ var style = localStorage.getItem('data-color-mode');
 iconElement = document.getElementById('github-icon');
 twitterIconElement = document.getElementById('twitter-icon');
 if (style == 'light') {
-  iconElement.setAttribute('fill', '#24292e');
-  twitterIconElement.setAttribute("fill","black")
+  if (iconElement) iconElement.setAttribute('fill', '#24292e');
+  if (twitterIconElement) twitterIconElement.setAttribute("fill","black")
 }
 else {
-  iconElement.removeAttribute('fill');
-  iconElement.setAttribute('class', 'octicon');
-  iconElement.setAttribute('color', '#f0f6fc');
-  twitterIconElement.setAttribute("fill","white")
+  if (iconElement) {
+    iconElement.removeAttribute('fill');
+    iconElement.setAttribute('class', 'octicon');
+    iconElement.setAttribute('color', '#f0f6fc');
+  }
+  if (twitterIconElement) twitterIconElement.setAttribute("fill","white")
 }
 </script>


### PR DESCRIPTION
When you hate Twitter after how awful it's got since it became "X" ... the code will throw a fatal error as `twitterIconElement` is `NULL` when unused - so `setAttribute()` isn't callable.

edit: And I guess it's unlikely given the purpose of this theme, but I've added the same checks for the github icon as well.