### PR TITLE
Fix: Replace Mobile Search Button with Three-bar-logo SVG, Retain Customizable Octocats

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -8,7 +8,10 @@
     <div class="Header-item d-md-none">
       <button class="Header-link btn-link js-details-target" type="button"
         onclick="document.querySelector('#header-search').style.display = document.querySelector('#header-search').style.display == 'none'? 'block': 'none'">
-        <img height="24" class="octicon octicon-three-bars" width="24" src="{{ .Site.Params.headerIcon }}">
+        <svg height="24" class="octicon octicon-three-bars" viewBox="0 0 16 16" version="1.1" width="24">
+          <path fill-rule="evenodd" d="M1 2.75A.75.75 0 011.75 2h12.5a.75.75 0 110 1.5H1.75A.75.75 0 011 2.75zm0 5A.75.75 0 011.75 7h12.5a.75.75 0 110 1.5H1.75A.75.75 0 011 7.75zM1.75 12a.75.75 0 100 1.5h12.5a.75.75 0 100-1.5H1.75z">
+          </path>
+        </svg>
       </button>
     </div>
     <div style="display: none;" id="header-search"


### PR DESCRIPTION
**Description:**

This PR aims to address an unintended change observed in mobile mode where the search button (previously a three-bar-logo) was inadvertently replaced with an octocat image. The initial goal, as outlined in #26 and #130, was to separate the octocat image for specific customizations without affecting other UI components, especially in mobile view.



<div>
<center>
    <img style="border-radius: 0.3125em;
    box-shadow: 0 2px 4px 0 rgba(34,36,38,.12),0 2px 10px 0 rgba(34,36,38,.08);" 
    src="https://raw.githubusercontent.com/looechao/blogimg/main/fix/fix-issue-01.png" width="50%">
    <br>
    <div style="color:orange; border-bottom: 0px solid #d9d9d9;
    display: inline-block;
    color: #999;
    padding: 2px;">The button for search</div>
</center>
</div>

<div>
<center>
    <img style="border-radius: 0.3125em;
    box-shadow: 0 2px 4px 0 rgba(34,36,38,.12),0 2px 10px 0 rgba(34,36,38,.08);" 
    src="https://raw.githubusercontent.com/looechao/blogimg/main/fix/fix-issue-03.png" width="50%">
    <br>
    <div style="color:orange; border-bottom: 0px solid #d9d9d9;
    display: inline-block;
    color: #999;
    padding: 2px;">Seems an inadvertently change</div>
</center>
</div>

**Changes Proposed:**

- Reintroduce the SVG version of the three-bar-logo for the search button in mobile mode. This ensures that the navigation UI remains intuitive and consistent across different device sizes.
- Maintain the separated octocat images in their designated areas as per the requirements of #26 and #130. **This change will not affect users' ability to customize their already separated octocat icons.**

<div>
<center>
    <img style="border-radius: 0.3125em;
    box-shadow: 0 2px 4px 0 rgba(34,36,38,.12),0 2px 10px 0 rgba(34,36,38,.08);" 
    src="https://raw.githubusercontent.com/looechao/blogimg/main/fix/fix-issue-02.png" width="50%">
    <br>
    <div style="color:orange; border-bottom: 0px solid #d9d9d9;
    display: inline-block;
    color: #999;
    padding: 2px;">The correct three-bar-logo on mobile mode</div>
</center>
</div>


**Request for Feedback:**

If these changes don't align with our project's goals, please feel free to close this PR. I'm open to feedback and ready to make any necessary adjustments. Thank you for your consideration.