### PR TITLE
Properly attribute GitHub trademarks

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -14,6 +14,7 @@
       {{ else }}
       <li class="mr-3 mr-lg-0">Theme by <a href='https://github.com/MeiK2333/github-style'>github-style</a></li>
       {{ end }}
+      <li class="mr-3 mr-lg-0">GitHub and the Invertocat logo are trademarks of <a href="https://github.com/">GitHub, Inc.</a></li>
     </ul>
   </div>
   <div class="d-flex flex-justify-center pb-6">


### PR DESCRIPTION
Resolves #156 (Logo fair usage violation) by adding 
```html
<li class="mr-3 mr-lg-0">GitHub and the Invertocat logo are trademarks of <a href="https://github.com/">[GitHub, Inc.](https://github.com/)</a></li>
```

below line 16 in the footer of the project.
<details><summary>Click to see preview</summary>
<img src="https://github.com/user-attachments/assets/5a3143bd-50dd-439c-be84-35e623ba8f64">
</details
