### PR TITLE
Break out javascript from inline to global.js to allow proper CSP headers

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -2,7 +2,6 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width">
     <script type="application/javascript" src='{{ "js/theme-mode.js" | absURL }}'></script>
-    <script type="application/javascript" src='{{ "js/global.js" | absURL }}'></script>
     <link rel="stylesheet" href='{{ "css/frameworks.min.css" | absURL }}' />
     <link rel="stylesheet" href='{{ "css/github.min.css" | absURL }}' />
     <link rel="stylesheet" href='{{ "css/github-style.css" | absURL }}' />

--- a/layouts/partials/user-profile.html
+++ b/layouts/partials/user-profile.html
@@ -194,3 +194,4 @@
     </div>
   </div>
 </div>
+<script type="application/javascript" src='{{ "js/global.js" | absURL }}'></script>

--- a/static/js/global.js
+++ b/static/js/global.js
@@ -15,9 +15,12 @@ window.addEventListener('load', function () {
         }
     };
     
-    document.getElementById("switch_theme_button").addEventListener("click", function () {
-        switchTheme();
-    });
+    const switch_theme_button = document.getElementById("switch_theme_button");
+    if (switch_theme_button) {
+        switch_theme_button.addEventListener("click", function () {
+            switchTheme();
+        });
+    }
     
     var style = localStorage.getItem('data-color-mode')
     githubIconElement = document.getElementById('github-icon')


### PR DESCRIPTION
First public PR here 👋 

I was working on the Content-Security-Policy (CSP) header for my blog based on this theme, but I ran into the issue of the inline JS-code needing hashes to properly configure the CSP. This is a viable option, but if the JS is ever changed in newer versions of the theme while the header is not updated, it will cause issues with loading the JS inside the browser. 

This PR aims to move the "global" JS into a separate file which can then be imported using the "src" attribute of the <script> element. Which, in turn, will allow the CSP header to not have static hashes for the inline JS.

Please feel free to edit the suggested code to fit your standards. 

Here are some relevant links:
https://scotthelme.co.uk/content-security-policy-an-introduction/
https://content-security-policy.com/unsafe-hashes/